### PR TITLE
Synchronize navigation and history between SCg iframe and SCn visualizer

### DIFF
--- a/src/components/Scg/types.ts
+++ b/src/components/Scg/types.ts
@@ -12,4 +12,5 @@ export const enum EWindowEvents {
   deleteScgElement = 'deleteScgElement',
   clearScene = 'clearScene',
   onInitializationFinished = 'onInitializationFinished',
+  commandExecuted = 'commandExecuted',
 }


### PR DESCRIPTION
Depends on [this commit in ostis-ai/sc-web](https://github.com/ostis-ai/sc-web/pull/154/commits/cfaaaabb383d1a58c225a75f50d7a580644b2584) from [this PR](https://github.com/ostis-ai/sc-web/pull/154)

The idea is to notify react-sc-web of every command that is being executed in the SCg view, so that question addresses will be known even for non-default or custom commands. The synchronization works because the question address is being taken by the switcher from the current URL, it's getting updated aswell.

Points of uncertainty: make sure the iframe page does not get soft- or hard-reloaded in case `scNavigation` is used. Network requests show that this does not happen, but the time of DOM refresh seems suspicious to me. Could just be the speed of SCg 🤷‍♂️