### PR TITLE
feat: change IRequest answer type

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "webpack serve --config webpack/webpack.dev",
+    "start:prod": "npm run build && serve -s build",
     "build": "webpack --config webpack/webpack.prod",
     "lint": "eslint --fix --ext .ts,.tsx ."
   },
@@ -23,6 +24,7 @@
     "react-hook-form": "^7.45.4",
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.15.0",
+    "serve": "^14.2.0",
     "yup": "^1.2.0"
   },
   "devDependencies": {

--- a/src/api/requests/getDescription.ts
+++ b/src/api/requests/getDescription.ts
@@ -136,7 +136,7 @@ export const getDescriptionByAddr = async (elementAddr: number) => {
 // };
 
 export const getDescriptionById = async (id: string, lang: TLanguage) => {
-  console.log("k");
+  const languageNode = await getLanguage(lang);
   const action = new Action('action_reply_to_message');
   const constr = new ScConstruction();
   constr.createLink(ScType.LinkConst, new ScLinkContent(id, ScLinkContentType.String));
@@ -149,7 +149,7 @@ export const getDescriptionById = async (id: string, lang: TLanguage) => {
 
   const res = await client.templateGenerate(textLinkTemplate);
 
-  await action.addArgs(linkAddr);
+  await action.addArgs(linkAddr, languageNode);
 
   const answerAddr = await action.initiate();
 

--- a/src/components/AskAnswer/AskAnswer.tsx
+++ b/src/components/AskAnswer/AskAnswer.tsx
@@ -1,27 +1,23 @@
-import { useToast, useTranslate } from 'ostis-ui-lib';
+import { useToast, useTranslate, Spinner, useLanguage } from 'ostis-ui-lib';
 
-import { useLocation } from 'react-router-dom';
 import { ChangeEvent, useEffect, useReducer, useState, useRef, useCallback } from 'react';
-
-import { Spinner, useLanguage } from 'ostis-ui-lib';
-import { SPINER_COLOR } from '@constants';
-import { AskElement } from './AskElement';
-import { TextItem } from '@components/AskAnswer/AskElement/AnswerText';
-
-import styles from './AskAnswer.module.scss';
-import { AskInput } from '@components/AskInput';
-
-import { getHintButtonHandler } from 'src/constants/hintButtons';
-import { getDescriptionById } from '@api/requests/getDescription';
 import { useDispatch, useSelector } from 'react-redux';
-import { addInHistory, selectRequests } from '@store/requestDialogHistorySlice';
+import { useLocation } from 'react-router-dom';
+
+import { getDescriptionById } from '@api/requests/getDescription';
+import { TextItem } from '@components/AskAnswer/AskElement/AnswerText';
+import { AskInput } from '@components/AskInput';
 import { Notification } from '@components/Notification';
+import { SPINER_COLOR } from '@constants';
+import { addInHistory, selectRequests } from '@store/requestDialogHistorySlice';
+import { getHintButtonHandler } from 'src/constants/hintButtons';
+import styles from './AskAnswer.module.scss';
+import { AskElement } from './AskElement';
 
 interface NavigateState {
   query?: string;
   isHintButton: boolean;
 }
-
 
 export const AskAnswer = () => {
   const state = useLocation().state as NavigateState;
@@ -59,17 +55,19 @@ export const AskAnswer = () => {
     }
 
     if (answer) {
-      const items: TextItem[] = [];
-      items.push({
-        type: 'normal',
-        content: answer,
-      });
+      const items: TextItem[] = [
+        {
+          type: 'normal',
+          content: answer,
+        },
+      ];
       dispatch(addInHistory({ query, answer: items }));
     } else {
       const items: TextItem[] = [];
       items.push({
         type: 'normal',
-        content: 'Unfortunately, there is currently no information corresponding to your question in the knowledge base. We apologize for the inconvenience.',
+        content:
+          'Unfortunately, there is currently no information corresponding to your question in the knowledge base. We apologize for the inconvenience.',
       });
       dispatch(addInHistory({ query, answer: items }));
       // dispatch(

--- a/src/components/AskAnswer/AskAnswer.tsx
+++ b/src/components/AskAnswer/AskAnswer.tsx
@@ -59,17 +59,28 @@ export const AskAnswer = () => {
     }
 
     if (answer) {
-      dispatch(addInHistory({ query, answer }));
+      const items: TextItem[] = [];
+      items.push({
+        type: 'normal',
+        content: answer,
+      });
+      dispatch(addInHistory({ query, answer: items }));
     } else {
-      dispatch(
-        addInHistory({
-          query,
-          answer: translate({
-            ru: 'К сожалению, в настоящее время нет информации, соответствующей вашему вопросу в базе знаний. Приносим извинения за неудобства.',
-            en: 'Unfortunately, there is currently no information corresponding to your question in the knowledge base. We apologize for the inconvenience.',
-          }),
-        }),
-      );
+      const items: TextItem[] = [];
+      items.push({
+        type: 'normal',
+        content: 'Unfortunately, there is currently no information corresponding to your question in the knowledge base. We apologize for the inconvenience.',
+      });
+      dispatch(addInHistory({ query, answer: items }));
+      // dispatch(
+      //   addInHistory({
+      //     query,
+      //     answer: translate({
+      //       ru: 'К сожалению, в настоящее время нет информации, соответствующей вашему вопросу в базе знаний. Приносим извинения за неудобства.',
+      //       en: 'Unfortunately, there is currently no information corresponding to your question in the knowledge base. We apologize for the inconvenience.',
+      //     }),
+      //   }),
+      // );
     }
 
     setIsLoading(false);

--- a/src/components/AskAnswer/AskElement/AnswerText.tsx
+++ b/src/components/AskAnswer/AskElement/AnswerText.tsx
@@ -26,14 +26,14 @@ export interface TextItem {
   content: string;
 }
 
-// export const AnswerText: React.FC<{
-//   items: TextItem[];
-// }> = ({ items }) => {
-//   return (
-//     <div>
-//       {items.map((item, index) => (
-//         <CollapsibleText key={index} {...item} />
-//       ))}
-//     </div>
-//   );
-// };
+export const AnswerText: React.FC<{
+  items: TextItem[];
+}> = ({ items }) => {
+  return (
+    <div>
+      {items.map((item, index) => (
+        <CollapsibleText key={index} {...item} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/AskAnswer/AskElement/AskElement.tsx
+++ b/src/components/AskAnswer/AskElement/AskElement.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import styles from './AskElement.module.scss';
-//import { AnswerText } from '@components/AskAnswer/AskElement/AnswerText';
+import { AnswerText } from '@components/AskAnswer/AskElement/AnswerText';
 
 import AskAIMessageIcon from '@assets/images/AskAIMessageIcon.svg';
 
@@ -15,7 +15,7 @@ export const AskElement: FC<IProps> = ({ query, answer }) => {
       <div className={styles.elementQuery}>{query}</div>
       <div className={styles.elementAnswer}>
         <div>{<AskAIMessageIcon />}</div>
-        {/* <div><AnswerText items={answer} /></div> */}
+        { <div><AnswerText items={answer} /></div> }
       </div>
     </div>
   );

--- a/src/store/requestDialogHistorySlice.ts
+++ b/src/store/requestDialogHistorySlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { TextItem } from '@components/AskAnswer/AskElement/AnswerText';
 import { IRootState } from '@store/model';
 
 export interface IRequest {
   query: string;
-  answer: any;
+  answer: TextItem[];
 }
 
 interface IInitialState {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `IRequest` answer type to `TextItem[]` and update components to handle this type.
> 
>   - **Behavior**:
>     - Change `answer` type in `IRequest` from `any` to `TextItem[]` in `requestDialogHistorySlice.ts`.
>     - Update `AskAnswer.tsx` to store answers as `TextItem[]` and dispatch them correctly.
>     - Modify `fetchAnswerByQuery` to create `TextItem[]` for both found and not found answers.
>   - **Components**:
>     - Enable `AnswerText` component in `AskElement.tsx` to render `TextItem[]`.
>     - Uncomment `AnswerText` usage in `AskElement.tsx`.
>   - **Misc**:
>     - Remove commented-out code for translation in `AskAnswer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Freact-sc-web&utm_source=github&utm_medium=referral)<sup> for 37abd9a9b6511ada4e8a2e8f5e17d9356d1d1111. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->